### PR TITLE
Allow libknot to autodiscover the library location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Once everything is in place, knot_exporter can be started like so:
 
 .. code-block:: bash
 
-   $ ./knot_exporter.py --knot-library-path /path/to/libknot.so
+   $ ./knot_exporter.py
 
 To get a complete list of the available options, run:
 

--- a/knot_exporter.py
+++ b/knot_exporter.py
@@ -165,7 +165,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         "--knot-library-path",
-        default="libknot.so",
+        default=None,
         help="path to libknot."
     )
 


### PR DESCRIPTION
When we default the library path to None we allow libknot to automatically discover¹ the proper library path.

Update the example to rely on this autodiscovery mechanism, to prevent eventual breakage from outdated library paths, when knot upgrades cross minor version boundaries.

[1] https://gitlab.nic.cz/knot/knot-dns/-/blob/v3.2.5/python/libknot/__init__.py.in#L39-51